### PR TITLE
Send endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b340e9cfa5b08690aae90fb61beb44e9b06f44fe3d0f93781aaa58cfba86245e"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +440,7 @@ dependencies = [
 name = "ecdsa-rust-server"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "hex",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,10 +229,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bitflags"
@@ -301,6 +313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const-oid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +354,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +373,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -366,6 +406,19 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
 ]
 
 [[package]]
@@ -373,8 +426,31 @@ name = "ecdsa-rust-server"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "hex",
+ "k256",
  "serde",
  "serde_json",
+ "sha3",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -384,6 +460,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -463,6 +549,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +591,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -552,6 +664,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "k256"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -700,6 +834,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +924,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +954,20 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -861,12 +1030,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -893,6 +1093,22 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -1128,6 +1344,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 actix-web = "4"
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
+k256 = { version = "0.11.6", features = ["ecdsa", "keccak256"] }
+sha3 = "0.10.6"
+hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = "1.0.89"
 k256 = { version = "0.11.6", features = ["ecdsa", "keccak256"] }
 sha3 = "0.10.6"
 hex = "0.4.3"
+actix-cors = "0.6.4"

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1,0 +1,38 @@
+use std::str::FromStr;
+
+use k256::ecdsa::{recoverable, Signature, VerifyingKey};
+use sha3::Digest;
+
+pub fn keccak256(message: impl AsRef<[u8]>) -> Vec<u8> {
+    let mut hasher = sha3::Keccak256::new();
+
+    hasher.update(message);
+
+    hasher.finalize().into_iter().collect()
+}
+
+pub fn get_address(hex_public_key: &str) -> Result<String, String> {
+    let byte_address = match hex::decode(hex_public_key) {
+        Ok(value) => value,
+        Err(_) => return Err(String::from("Invalid hex string")),
+    };
+
+    let (_, address) = byte_address.split_at(1);
+
+    let hashed_pub_key = keccak256(address);
+
+    let (_, partial_address) = hashed_pub_key.split_at(12);
+
+    Ok(hex::encode(partial_address))
+}
+
+pub fn recover_key(message: &[u8], hex_signature: &str, recovery_id: u8) -> VerifyingKey {
+    let raw_signature = Signature::from_str(hex_signature).unwrap();
+    let parsed_recovery_id = recoverable::Id::new(recovery_id).unwrap();
+
+    let signature = recoverable::Signature::new(&raw_signature, parsed_recovery_id).unwrap();
+
+    // Do not hash the data again because by having the keccak256 flag enabled,
+    // recover_verifying_key will hash the data for you to recover the pub key.
+    signature.recover_verifying_key(message).unwrap()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod eth;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,22 @@
 use std::{collections::HashMap, sync::RwLock};
 
+use actix_cors::Cors;
 use actix_web::{
     body::BoxBody, get, http::header::ContentType, post, web, App, HttpResponse, HttpServer,
     Responder,
 };
-use serde::Serialize;
+use ecdsa_rust_server::eth::{get_address, recover_key};
+use serde::{Deserialize, Serialize};
+
+// Ethereum accounts from Hardhat
+// Account #0: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
+// Private Key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+// Account #1: 0x70997970c51812dc3a010c7d01b50e0d17dc79c8
+// Private Key: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+
+// Account #2: 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc
+// Private Key: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
 
 struct Balances {
     // RwLock is needed to safely share the same data between the different App instaces spawned by Actix.
@@ -13,8 +25,23 @@ struct Balances {
 
 impl Balances {
     pub fn new() -> Self {
+        let mut balances: HashMap<String, i128> = HashMap::new();
+
+        balances.insert(
+            String::from("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"),
+            150,
+        );
+        balances.insert(
+            String::from("70997970c51812dc3a010c7d01b50e0d17dc79c8"),
+            150,
+        );
+        balances.insert(
+            String::from("3c44cdddb6a900fa2b585dd299e03d12fa4293bc"),
+            150,
+        );
+
         Self {
-            balances: RwLock::new(HashMap::new()),
+            balances: RwLock::new(balances),
         }
     }
 }
@@ -37,6 +64,20 @@ impl Responder for BalanceResponse {
     }
 }
 
+#[derive(Deserialize, Debug)]
+struct Transaction {
+    amount: i128,
+    to: String,
+    s: String,
+    r: u8,
+}
+
+#[derive(Serialize)]
+struct TransactionData {
+    amount: i128,
+    to: String,
+}
+
 #[get("/balance/{address}")]
 async fn get_address_balance(
     data: web::Data<Balances>,
@@ -50,9 +91,42 @@ async fn get_address_balance(
     }
 }
 
+// TODO: add better error management.
 #[post("/send")]
-async fn send_transaction() -> impl Responder {
-    HttpResponse::Ok()
+async fn send_transaction(
+    data: web::Data<Balances>,
+    transaction: web::Json<Transaction>,
+) -> impl Responder {
+    let transaction_data = TransactionData {
+        amount: transaction.amount,
+        to: transaction.to.clone(),
+    };
+
+    let raw_data = serde_json::to_string(&transaction_data).unwrap();
+
+    let sender_pub_key = recover_key(raw_data.as_bytes(), &transaction.s, transaction.r).unwrap();
+
+    let sender_address = get_address(&sender_pub_key).unwrap();
+
+    let mut balances = data.balances.write().unwrap();
+
+    let sender_balance = balances.entry(sender_address.clone()).or_insert(0);
+
+    if *sender_balance < transaction.amount {
+        return BalanceResponse { balance: 0 };
+    }
+
+    *sender_balance -= transaction.amount;
+
+    let receiver_balancer = balances.entry(transaction.to.clone()).or_insert(0);
+    *receiver_balancer += transaction.amount;
+
+    // It is safe to call unwrap because the key exists now.
+    let sender_balance = balances.get(&sender_address).unwrap();
+
+    BalanceResponse {
+        balance: *sender_balance,
+    }
 }
 
 #[actix_web::main]
@@ -60,12 +134,15 @@ async fn main() -> std::io::Result<()> {
     let balances = web::Data::new(Balances::new());
 
     HttpServer::new(move || {
+        let cors = Cors::permissive();
+
         App::new()
             .app_data(balances.clone())
+            .wrap(cors)
             .service(get_address_balance)
             .service(send_transaction)
     })
-    .bind(("127.0.0.1", 3000))?
+    .bind(("127.0.0.1", 3042))?
     .run()
     .await
 }


### PR DESCRIPTION
### Changelog

- Implements the `keccak256` , `get_address` and `recover_key` functions to handle Ethereum like transactions
- Adds default accounts from Hardhat
- implements the `send_transaction` function for the `/send` endpoint